### PR TITLE
Specify https url for Package-Builder submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Package-Builder"]
 	path = Package-Builder
-	url = git@github.com:IBM-Swift/Package-Builder.git
+	url = https://github.com/IBM-Swift/Package-Builder.git


### PR DESCRIPTION
Before this change, when I attempt to clone down the main repo using `git clone https://github.com/akrabat/kitura_bookshelfapi.git --recursive` the clone fails with the following error:

```
Cloning into 'kitura_bookshelfapi'...
remote: Counting objects: 105, done.
remote: Total 105 (delta 0), reused 0 (delta 0), pack-reused 105
Receiving objects: 100% (105/105), 15.51 KiB | 0 bytes/s, done.
Resolving deltas: 100% (40/40), done.
Submodule 'Package-Builder' (git@github.com:IBM-Swift/Package-Builder.git) registered for path 'Package-Builder'
Cloning into '/Users/<username>/kitura_bookshelfapi/Package-Builder'...
Permission denied (publickey).
fatal: Could not read from remote repository.
```

I'm guessing my SSH setup isn't the same as the original authors, but this change should fix it in any case. Now when I clone down the repo everything transfers fine. The `make` command successfully builds the app, and `docker-compose up` successfully launches the app as containers.